### PR TITLE
update linter to cover server side code as well as client side. tweak…

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -3,7 +3,7 @@
   "browser": true,
   "esnext": true,
   "bitwise": true,
-  "camelcase": true,
+  "camelcase": false,
   "curly": true,
   "eqeqeq": true,
   "immed": true,
@@ -18,6 +18,8 @@
   "trailing": true,
   "smarttabs": true,
   "globals": {
-    "angular": true
+    "angular": true,
+    "describe": true,
+    "it": true
   }
 }

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -129,14 +129,16 @@ module.exports = function (grunt) {
       all: {
         src: [
           'Gruntfile.js',
+          'server/**/**/*.js',
           '<%= appSettings.app %>/{,*/}*.js',
+          '<%= appSettings.app %>/app/{services,views,components}/**/*.js',
           '<%= appSettings.app %>/app/{services,views,components}/**/*.js',
           '!<%= appSettings.app %>/app/{services,views,components}/**/*.spec.js'
         ]
       },
       test: {
         options: {
-          jshintrc: '<%= appSettings.app %>/test/.jshintrc'
+          jshintrc: '.jshintrc'
         },
         src: ['<%= appSettings.app %>/test/spec/{,*/}*.js']
       }
@@ -165,7 +167,7 @@ module.exports = function (grunt) {
       },
       server : {
         src: [
-          'server/**/*.js'
+          'server/**/**/*.js'
         ],
         options: {
           destination: 'doc/server',

--- a/package.json
+++ b/package.json
@@ -44,9 +44,10 @@
     "node": ">=0.12.2"
   },
   "scripts": {
-    "serve": "node node_modules/grunt-cli/bin/grunt serve",
+    "server": "node node_modules/grunt-cli/bin/grunt serve",
     "build": "node node_modules/grunt-cli/bin/grunt && npm run test-server && npm run report",
     "docs": "node node_modules/grunt-cli/bin/grunt jsdoc",
+    "linter": "node node_modules/grunt-cli/bin/grunt jshint",
 
     "test": "npm run test-client && npm run test-server && npm run report",
     "test-client": "node node_modules/grunt-cli/bin/grunt test",

--- a/server/api/fda/fda.controller.js
+++ b/server/api/fda/fda.controller.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var request = require('request'),
     config  = require('../../config'),
     fdaUrl  = config.fdaUrl,
@@ -17,13 +19,13 @@ var fda = {};
  * A simple proxy for the FDA api data that also attaches the FDA api key
  */
 fda.getFDA = function getFDA(req, res) {
-  var qs = req.query,
+  var qs     = req.query,
       params = req.params;
 
   qs.api_key = qs.api_key || apiKey;
 
   var opts = {
-    qs: qs,
+    qs       : qs,
     keepAlive: true
   };
 

--- a/server/api/fda/fda.spec.js
+++ b/server/api/fda/fda.spec.js
@@ -1,17 +1,20 @@
+'use strict';
+
 var assert  = require('assert'),
     request = require('supertest'),
-    app     = require('../../app'),
-    fda     = require('./fda.controller');
+    app     = require('../../app');
 
-describe('GET /fda/drug/event.json', function() {
+describe('GET /fda/drug/event.json', function () {
 
-  it('should respond with JSON array', function(done) {
+  it('should respond with JSON array', function (done) {
     request(app)
       .get('/fda/drug/event.json')
       .expect('Content-Type', /json/)
       .expect(200)
-      .end(function(err, res) {
-        if (err) return done(err);
+      .end(function (err, res) {
+        if (err) {
+          return done(err);
+        }
 
         assert(res.body.results.length > 0);
 

--- a/server/api/user/user.controller.js
+++ b/server/api/user/user.controller.js
@@ -19,11 +19,13 @@ user.login = function (req, res) {
   };
 
   firebaseRef.authWithPassword(opts, function (error, authData) {
-    if (error) { return res.send(500, error) }
+    if (error) {
+      return res.send(500, error);
+    }
 
     res.json('Authenticated successfully with payload:', authData);
   });
-  
+
 };
 
 /**
@@ -41,7 +43,9 @@ user.createUser = function (req, res) {
   };
 
   firebaseRef.createUser(opts, function (error, userData) {
-    if (error) { return res.send(500, error) }
+    if (error) {
+      return res.send(500, error);
+    }
 
     res.json('Successfully created user account with uid:', userData.uid);
   });

--- a/server/api/user/user.spec.js
+++ b/server/api/user/user.spec.js
@@ -1,7 +1,9 @@
-var assert  = require('assert'),
-    request = require('supertest'),
-    app     = require('../../app'),
-    fda     = require('./user.controller');
+'use strict';
+
+//var assert  = require('assert'),
+//    request = require('supertest'),
+//    app     = require('../../app'),
+//    fda     = require('./user.controller');
 
 describe('GET /fda/drug/event.json', function() {
 

--- a/server/app-server.js
+++ b/server/app-server.js
@@ -1,3 +1,5 @@
+'use strict';
+
 /**
  * @namespace app-server
  *
@@ -8,6 +10,6 @@ var app    = require('./app'),
     port   = require('./config').port,
     server = require('http').createServer(app);
 
-server.listen(port, function() {
+server.listen(port, function () {
   console.log('listen on port ' + port);
 });

--- a/server/app.js
+++ b/server/app.js
@@ -15,7 +15,7 @@ var app = express(); // create the express app
 
 app.use(express.static(config.appDir)); // use the static app directory
 app.use(bodyparser.json());
-app.use(bodyparser.urlencoded({ extended: false }));
+app.use(bodyparser.urlencoded({extended: false}));
 
 require('./router')(app); // include the router
 

--- a/server/config.js
+++ b/server/config.js
@@ -1,3 +1,5 @@
+'use strict';
+
 /**
  * @namespace config
  *
@@ -12,10 +14,10 @@ var config = {
   fdaUrl: 'https://api.fda.gov/',
 
   // api key for fda data
-  fdaKey: (function() {
+  fdaKey: (function () {
     var key = process.env.FDA_KEY;
 
-    if(!key) {
+    if (!key) {
       console.log(chalk.magenta('### No API key has been attached. For production please provide and FDA API key. (FDA_KEY=thisisthekeyigotfromfda)'));
     }
 

--- a/server/router.js
+++ b/server/router.js
@@ -1,3 +1,5 @@
+'use strict';
+
 /**
  * @namespace router
  *

--- a/server/tests/unit.js
+++ b/server/tests/unit.js
@@ -1,11 +1,13 @@
+'use strict';
+
 var fs = require('fs');
 
 var tests = fs.readdirSync(__dirname + '/../api');
 
 var createPath = function (name) {
-  return '../api/' + name + '/' + name + '.spec'
+  return '../api/' + name + '/' + name + '.spec';
 };
 
-tests.forEach(function(test) {
+tests.forEach(function (test) {
   require(createPath(test));
 });


### PR DESCRIPTION
… linter rules to allow for _ var names (ex. foo_bar)
